### PR TITLE
Raf/distribution bar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@radix-ui/react-icons": "^1.3.0",
         "@radix-ui/react-label": "^2.1.0",
         "@radix-ui/react-popover": "^1.1.1",
+        "@radix-ui/react-progress": "^1.1.0",
         "@radix-ui/react-radio-group": "^1.2.0",
         "@radix-ui/react-select": "^2.1.1",
         "@radix-ui/react-separator": "^1.1.0",
@@ -1604,6 +1605,43 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-progress": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-progress/-/react-progress-1.1.0.tgz",
+      "integrity": "sha512-aSzvnYpP725CROcxAOEBVZZSIQVQdHgBr2QQFKySsaD14u8dNT0batuXI+AAGDdAHfXH8rbnHmjYFqVJ21KkRg==",
+      "dependencies": {
+        "@radix-ui/react-context": "1.1.0",
+        "@radix-ui/react-primitive": "2.0.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-progress/node_modules/@radix-ui/react-context": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.0.tgz",
+      "integrity": "sha512-OKrckBy+sMEgYM/sMmqmErVn0kZqrHPJze+Ql3DzYsDDp0hl0L62nx/2122/Bvps1qz645jlcu2tD9lrRSdf8A==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@radix-ui/react-icons": "^1.3.0",
     "@radix-ui/react-label": "^2.1.0",
     "@radix-ui/react-popover": "^1.1.1",
+    "@radix-ui/react-progress": "^1.1.0",
     "@radix-ui/react-radio-group": "^1.2.0",
     "@radix-ui/react-select": "^2.1.1",
     "@radix-ui/react-separator": "^1.1.0",

--- a/src/components/DistributionBar/DistributionBar.module.scss
+++ b/src/components/DistributionBar/DistributionBar.module.scss
@@ -1,0 +1,26 @@
+.distributionBar {
+  position: relative;
+  width: 100%;
+  height: 1rem;
+  border-radius: 4px;
+  overflow: hidden;
+  display: flex;
+}
+
+.distributionSegment {
+  height: 100%;
+  border-radius: 4px;
+  background-image: repeating-linear-gradient(
+    to right,
+    rgba(0, 0, 0, 0.2),
+    rgba(0, 0, 0, 0.2) 1px,
+    transparent 1px,
+    transparent 5px
+  );
+  background-size: 5px 100%;
+  background-position: 0 0;
+}
+
+.segmentWithGap {
+  margin-left: var(--segment-gap, 4px);
+}

--- a/src/components/DistributionBar/DistributionBar.tsx
+++ b/src/components/DistributionBar/DistributionBar.tsx
@@ -22,16 +22,26 @@ export const DistributionBar: React.FC<DistributionBarProps> = ({
     return null;
   }
 
+  const gap = 4;
+
+  // Calculate adjusted widths to account for gaps
+  const adjustedValues = values.map((value) => {
+    // Reduce each value's width proportionally by the total gap space
+    const totalGapsPercentage = (gap / 100) * (values.length - 1);
+    return value - value * totalGapsPercentage;
+  });
+
   return (
-    <div className="relative w-full h-4 bg-gray-200 rounded-lg overflow-hidden flex">
-      {values.map((value, index) => (
+    <div className="relative w-full h-4 rounded-[4px] overflow-hidden flex">
+      {adjustedValues.map((value, index) => (
         <div
           key={index}
           style={{
-            width: `${value}%`,
+            width: `${value}%`, // Adjusted width
             backgroundColor: colors[index],
+            marginLeft: index === 0 ? 0 : `${gap}px`, // Add gap between segments
           }}
-          className="h-full"
+          className="h-full rounded-[4px]" // Add rounded corners to individual segments
         />
       ))}
     </div>

--- a/src/components/DistributionBar/DistributionBar.tsx
+++ b/src/components/DistributionBar/DistributionBar.tsx
@@ -1,47 +1,55 @@
 import React from 'react';
 
+import styles from './DistributionBar.module.scss';
+
 type DistributionBarProps = {
-  values: number[]; // Array of percentages
-  colors: string[]; // Corresponding colors
+  values: number[];
+  colors: string[];
+  gap?: number; //Default 4px
+};
+
+type CSSWithCustomProps = React.CSSProperties & {
+  '--segment-gap'?: string;
 };
 
 export const DistributionBar: React.FC<DistributionBarProps> = ({
   values,
   colors,
+  gap = 4,
 }) => {
-  // Validate input lengths
   if (values.length !== colors.length) {
     console.error('The number of values must match the number of colors.');
     return null;
   }
 
-  // Ensure percentages sum to 100% or less
   const total = values.reduce((sum, val) => sum + val, 0);
-  if (total > 100) {
-    console.error('Progress values exceed 100%.');
+  if (total !== 100) {
+    console.error('Progress values do not add up to 100%.');
     return null;
   }
 
-  const gap = 4;
+  const totalGapSpace = (values.length - 1) * gap;
+  const remainingWidth = 100 - totalGapSpace;
 
-  // Calculate adjusted widths to account for gaps
-  const adjustedValues = values.map((value) => {
-    // Reduce each value's width proportionally by the total gap space
-    const totalGapsPercentage = (gap / 100) * (values.length - 1);
-    return value - value * totalGapsPercentage;
-  });
+  const adjustedValues = values.map(
+    (value) => (value / total) * remainingWidth
+  );
 
   return (
-    <div className="relative w-full h-4 rounded-[4px] overflow-hidden flex">
+    <div className={styles.distributionBar}>
       {adjustedValues.map((value, index) => (
         <div
           key={index}
-          style={{
-            width: `${value}%`, // Adjusted width
-            backgroundColor: colors[index],
-            marginLeft: index === 0 ? 0 : `${gap}px`, // Add gap between segments
-          }}
-          className="h-full rounded-[4px]" // Add rounded corners to individual segments
+          style={
+            {
+              width: `${value}%`,
+              backgroundColor: colors[index],
+              '--segment-gap': `${gap}px`,
+            } as CSSWithCustomProps
+          }
+          className={`${styles.distributionSegment} ${
+            index !== 0 ? styles.segmentWithGap : ''
+          }`}
         />
       ))}
     </div>

--- a/src/components/DistributionBar/DistributionBar.tsx
+++ b/src/components/DistributionBar/DistributionBar.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+
+type DistributionBarProps = {
+  values: number[]; // Array of percentages
+  colors: string[]; // Corresponding colors
+};
+
+export const DistributionBar: React.FC<DistributionBarProps> = ({
+  values,
+  colors,
+}) => {
+  // Validate input lengths
+  if (values.length !== colors.length) {
+    console.error('The number of values must match the number of colors.');
+    return null;
+  }
+
+  // Ensure percentages sum to 100% or less
+  const total = values.reduce((sum, val) => sum + val, 0);
+  if (total > 100) {
+    console.error('Progress values exceed 100%.');
+    return null;
+  }
+
+  return (
+    <div className="relative w-full h-4 bg-gray-200 rounded-lg overflow-hidden flex">
+      {values.map((value, index) => (
+        <div
+          key={index}
+          style={{
+            width: `${value}%`,
+            backgroundColor: colors[index],
+          }}
+          className="h-full"
+        />
+      ))}
+    </div>
+  );
+};

--- a/src/components/DistributionBar/index.tsx
+++ b/src/components/DistributionBar/index.tsx
@@ -1,0 +1,1 @@
+export { DistributionBar } from './DistributionBar';

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -1,0 +1,26 @@
+import * as React from "react"
+import * as ProgressPrimitive from "@radix-ui/react-progress"
+
+import { cn } from "@/lib/utils"
+
+const Progress = React.forwardRef<
+  React.ElementRef<typeof ProgressPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root>
+>(({ className, value, ...props }, ref) => (
+  <ProgressPrimitive.Root
+    ref={ref}
+    className={cn(
+      "relative h-4 w-full overflow-hidden rounded-full bg-secondary",
+      className
+    )}
+    {...props}
+  >
+    <ProgressPrimitive.Indicator
+      className="h-full w-full flex-1 bg-primary transition-all"
+      style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
+    />
+  </ProgressPrimitive.Root>
+))
+Progress.displayName = ProgressPrimitive.Root.displayName
+
+export { Progress }

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -1,7 +1,7 @@
-import * as React from "react"
-import * as ProgressPrimitive from "@radix-ui/react-progress"
+import * as React from 'react';
+import * as ProgressPrimitive from '@radix-ui/react-progress';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
 const Progress = React.forwardRef<
   React.ElementRef<typeof ProgressPrimitive.Root>,
@@ -10,7 +10,7 @@ const Progress = React.forwardRef<
   <ProgressPrimitive.Root
     ref={ref}
     className={cn(
-      "relative h-4 w-full overflow-hidden rounded-full bg-secondary",
+      'relative h-4 w-full overflow-hidden rounded-full bg-secondary',
       className
     )}
     {...props}
@@ -20,7 +20,7 @@ const Progress = React.forwardRef<
       style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
     />
   </ProgressPrimitive.Root>
-))
-Progress.displayName = ProgressPrimitive.Root.displayName
+));
+Progress.displayName = ProgressPrimitive.Root.displayName;
 
-export { Progress }
+export { Progress };

--- a/src/pages/Accounts/Accounts.tsx
+++ b/src/pages/Accounts/Accounts.tsx
@@ -1,6 +1,7 @@
 import { Plus } from 'lucide-react';
 import React from 'react';
 
+import { DistributionBar } from '@/components/DistributionBar';
 import { Typography } from '@/components/Typography';
 import { Button } from '@/components/ui/button';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -27,6 +28,14 @@ export const Accounts: React.FC = () => {
           <TabsTrigger value="creditcards">Credit Cards</TabsTrigger>
         </TabsList>
       </Tabs>
+
+      <div className="p-6">
+        <h1 className="text-white">Distribution</h1>
+        <DistributionBar
+          values={[33, 44, 23]} // Percentages
+          colors={['#FF5733', '#3498DB', '#2ECC71']} // Red, Blue, Green
+        />
+      </div>
     </div>
   );
 };

--- a/src/pages/Accounts/Accounts.tsx
+++ b/src/pages/Accounts/Accounts.tsx
@@ -28,14 +28,6 @@ export const Accounts: React.FC = () => {
           <TabsTrigger value="creditcards">Credit Cards</TabsTrigger>
         </TabsList>
       </Tabs>
-
-      <div className="p-6">
-        <h1 className="text-white">Distribution</h1>
-        <DistributionBar
-          values={[33, 44, 23]} // Percentages
-          colors={['#FF5733', '#3498DB', '#2ECC71']} // Red, Blue, Green
-        />
-      </div>
     </div>
   );
 };

--- a/src/pages/Accounts/Accounts.tsx
+++ b/src/pages/Accounts/Accounts.tsx
@@ -1,7 +1,6 @@
 import { Plus } from 'lucide-react';
 import React from 'react';
 
-import { DistributionBar } from '@/components/DistributionBar';
 import { Typography } from '@/components/Typography';
 import { Button } from '@/components/ui/button';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';


### PR DESCRIPTION
Created distribution bar component for Accounts tab.

## Changes

- Used Shad's progress bar as a base
- The custom distribution bar component takes an array of percentages and an array of hexcodes as input to give a visual distribution in a bar format
- The bar checks if the breakdown adds up to 100%

## Screenshots (if appropriate)

![image](https://github.com/user-attachments/assets/7e5589c4-d02f-4a18-896d-651c00bb1807)

## Test Steps

<!-- Add any test steps for reviewers to follow. -->

## Related PRs (if any)

<!-- Add links to any related PRs. -->
